### PR TITLE
[ENH] Add a property 'window' to auditory stimuli

### DIFF
--- a/doc/changes/latest.rst
+++ b/doc/changes/latest.rst
@@ -19,6 +19,8 @@ Enhancements
 
 - Add the documentation build (by `Mathieu Scheltienne`_ in :pr:`6`)
 
+- Add ``window`` property for auditory stimuli (by `Mathieu Scheltienne`_ in :pr:`12`)
+
 Bugs
 ~~~~
 

--- a/stimuli/audio/am.py
+++ b/stimuli/audio/am.py
@@ -81,6 +81,7 @@ class SoundAM(BaseSound):
             )
         arr /= np.max(np.abs(arr))  # normalize
         self._signal = np.vstack((arr, arr)).T * self._volume / 100
+        super()._set_signal()
 
     # --------------------------------------------------------------------
     @staticmethod

--- a/stimuli/audio/base.py
+++ b/stimuli/audio/base.py
@@ -41,7 +41,7 @@ class BaseSound(ABC):
         self._set_signal()
 
     def _set_times(self) -> None:
-        """Update the time array annd the ._signal variable."""
+        """Update the time array and the ._signal variable."""
         logger.debug(
             "Setting the 'times' array with the duration %.2f "
             "[seconds] and the sampling rate %.1f [Hz].",

--- a/stimuli/audio/base.py
+++ b/stimuli/audio/base.py
@@ -227,3 +227,8 @@ class BaseSound(ABC):
             assert window.size == self._times.size
         self._window = window
         self._set_signal()
+
+    @property
+    def n_samples(self) -> int:
+        """Number of samples."""
+        return self._times.size

--- a/stimuli/audio/base.py
+++ b/stimuli/audio/base.py
@@ -3,7 +3,7 @@
 from abc import ABC, abstractmethod
 from os import makedirs
 from pathlib import Path
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import sounddevice as sd
@@ -36,6 +36,7 @@ class BaseSound(ABC):
         self._volume = BaseSound._check_volume(volume)
         self._sample_rate = BaseSound._check_sample_rate(sample_rate)
         self._duration = BaseSound._check_duration(duration)
+        self._window = None  # rectangular window applied by default
         self._set_times()
         self._set_signal()
 
@@ -58,7 +59,8 @@ class BaseSound(ABC):
     def _set_signal(self) -> None:
         """Set the signal in the numpy array ._signal played by sounddevice."""
         # [:, 0] for left and [:, 1] for right
-        self._signal = np.zeros(shape=(self._times.size, 2))
+        if self._window is not None:
+            self._signal = np.multiply(self._window, self._signal.T).T
 
     # --------------------------------------------------------------------
     def play(self, blocking: bool = False) -> None:
@@ -211,3 +213,17 @@ class BaseSound(ABC):
     def times(self) -> NDArray[float]:
         """Times array."""
         return self._times
+
+    @property
+    def window(self) -> Optional[NDArray[float]]:
+        """Window applied to the signal."""
+        return self._window
+
+    @window.setter
+    def window(self, window: Optional[NDArray[float]]):
+        _check_type(window, (None, np.ndarray), "window")
+        if window is not None:
+            assert window.ndim == 1
+            assert window.size == self._times.size
+        self._window = window
+        self._set_signal()

--- a/stimuli/audio/noise.py
+++ b/stimuli/audio/noise.py
@@ -51,6 +51,7 @@ class Noise(BaseSound):
         noise_arr = Noise._noise_psd(self._rng, self._times.size, self._color)
         noise_arr /= np.max(np.abs(noise_arr))  # normalize
         self._signal = np.vstack((noise_arr, noise_arr)).T * self._volume / 100
+        super()._set_signal()
 
     # --------------------------------------------------------------------
     @staticmethod

--- a/stimuli/audio/sound.py
+++ b/stimuli/audio/sound.py
@@ -40,6 +40,7 @@ class Sound(BaseSound):
         tmax = None if self._tmax is None else self._tmax + 1  # +1 for slice
         slc = (slice(self._tmin, tmax), slice(None))
         self._signal = self._original_signal[slc] * self._volume / 100
+        super()._set_signal()
 
     def crop(
         self, tmin: Optional[float] = None, tmax: Optional[float] = None

--- a/stimuli/audio/tests/test_am.py
+++ b/stimuli/audio/tests/test_am.py
@@ -5,7 +5,7 @@ import pytest
 from scipy.signal import find_peaks
 
 from .. import SoundAM
-from .test_base import _test_base, _test_no_volume
+from .test_base import _test_base, _test_no_volume, _test_window
 
 
 def _check_frequency(signal, sample_rate, carrier, modulation, method):
@@ -136,3 +136,8 @@ def test_base():
 def test_no_volume():
     """Test signal if volume is set to 0."""
     _test_no_volume(SoundAM)
+
+
+def test_window():
+    """Test application of a window."""
+    _test_window(SoundAM)

--- a/stimuli/audio/tests/test_tone.py
+++ b/stimuli/audio/tests/test_tone.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from .. import Tone
-from .test_base import _test_base, _test_no_volume
+from .test_base import _test_base, _test_no_volume, _test_window
 
 
 def _check_frequency(signal, sample_rate, target):
@@ -57,3 +57,8 @@ def test_base():
 def test_no_volume():
     """Test signal if volume is set to 0."""
     _test_no_volume(Tone)
+
+
+def test_window():
+    """Test application of a window."""
+    _test_window(Tone)

--- a/stimuli/audio/tone.py
+++ b/stimuli/audio/tone.py
@@ -52,6 +52,7 @@ class Tone(BaseSound):
         tone_arr = np.sin(2 * np.pi * self._frequency * self._times)
         tone_arr /= np.max(np.abs(tone_arr))  # normalize
         self._signal = np.vstack((tone_arr, tone_arr)).T * self._volume / 100
+        super()._set_signal()
 
     # --------------------------------------------------------------------
     @staticmethod


### PR DESCRIPTION
Add a property 'window' which can be set to either `None` (no-window -> rectangular window) or to a `np.ndarray` of shape `(n_samples,)`.